### PR TITLE
import numpy's random module from numpy instead of scipy

### DIFF
--- a/gigrnd.py
+++ b/gigrnd.py
@@ -9,7 +9,7 @@ Reference: L Devroye. Random variate generation for the generalized inverse Gaus
 
 
 import math
-from scipy import random
+from numpy import random
 
 
 def psi(x, alpha, lam):

--- a/mcmc_gtb.py
+++ b/mcmc_gtb.py
@@ -8,7 +8,7 @@ Markov Chain Monte Carlo (MCMC) sampler for polygenic prediction with continuous
 
 import scipy as sp
 from scipy import linalg 
-from scipy import random
+from numpy import random
 import gigrnd
 
 


### PR DESCRIPTION
Scipy no longer exports numpy's random module. We can import it directly from numpy instead.

This fixes https://github.com/getian107/PRScs/issues/49